### PR TITLE
Rename JSONPath to ReferencePath

### DIFF
--- a/src/awsstepfuncs/abstract_state.py
+++ b/src/awsstepfuncs/abstract_state.py
@@ -9,7 +9,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
-from awsstepfuncs.json_path import ReferencePath
+from awsstepfuncs.reference_path import ReferencePath
 from awsstepfuncs.types import ResourceToMockFn
 
 MAX_STATE_NAME_LENGTH = 128
@@ -373,11 +373,11 @@ class AbstractResultSelectorState(AbstractParametersState):
             ValueError: Raised when a key doesn't end with ".$".
             ValueError: Raised when a ReferencePath is invalid.
         """
-        for key, json_path in result_selector.items():
+        for key, reference_path in result_selector.items():
             if not key[-2:] == ".$":
                 raise ValueError("All resource selector keys must end with .$")
 
-            ReferencePath(json_path)
+            ReferencePath(reference_path)
 
     def compile(self) -> Dict[str, Any]:  # noqa: A003
         """Compile the state to Amazon States Language.
@@ -423,9 +423,9 @@ class AbstractResultSelectorState(AbstractParametersState):
             The filtered state output.
         """
         new_state_output = {}
-        for key, json_path in self.result_selector.items():  # type: ignore
+        for key, reference_path in self.result_selector.items():  # type: ignore
             key = key[:-2]  # Strip ".$"
-            if extracted := ReferencePath(json_path).apply(state_output):
+            if extracted := ReferencePath(reference_path).apply(state_output):
                 new_state_output[key] = extracted
 
         return new_state_output

--- a/src/awsstepfuncs/json_path.py
+++ b/src/awsstepfuncs/json_path.py
@@ -3,24 +3,24 @@ from typing import Any
 from jsonpath_rw import parse as parse_jsonpath
 
 
-class JSONPath:
-    """JSONPath validation and application.
+class ReferencePath:
+    """ReferencePath validation and application.
 
     See: https://github.com/json-path/JsonPath
     """
 
     def __init__(self, json_path: str, /):
-        """Initialize a JSONPath.
+        """Initialize a ReferencePath.
 
-        >>> json_path = JSONPath("$.detail.sum")
+        >>> json_path = ReferencePath("$.detail.sum")
         >>> json_path.apply({"show": True, "detail": {"mean": 10.4, "sum": 2000}})
         2000
 
         Args:
-            json_path: The JSONPath string to use.
+            json_path: The ReferencePath string to use.
 
         Raises:
-            ValueError: Raised when the JSONPath is malformed.
+            ValueError: Raised when the ReferencePath is malformed.
         """
         self.json_path = json_path or "$"
         try:
@@ -31,52 +31,52 @@ class JSONPath:
     def __repr__(self) -> str:
         """Return the string representation of the class.
 
-        >>> JSONPath("$.detail.sum")
-        JSONPath('$.detail.sum')
+        >>> ReferencePath("$.detail.sum")
+        ReferencePath('$.detail.sum')
 
         Returns:
-            The string representation of the JSONPath.
+            The string representation of the ReferencePath.
         """
         return f"{self.__class__.__name__}({self.json_path!r})"
 
     def __str__(self) -> str:
-        """Return the JSONPath string.
+        """Return the ReferencePath string.
 
-        >>> json_path = JSONPath("$.detail.sum")
+        >>> json_path = ReferencePath("$.detail.sum")
         >>> print(json_path)
         $.detail.sum
 
         Returns:
-            The human-readable string representation of the JSONPath.
+            The human-readable string representation of the ReferencePath.
         """
         return self.json_path
 
     def __bool__(self) -> bool:
-        """Whether the JSONPath has something besides $ (default)."""
+        """Whether the ReferencePath has something besides $ (default)."""
         return self.json_path != "$"
 
     def _validate(self) -> None:
-        """Validate a JSONPath for Amazon States Language.
+        """Validate a ReferencePath for Amazon States Language.
 
         Raises:
-            ValueError: Raised when JSONPath is an empty string or does not
+            ValueError: Raised when ReferencePath is an empty string or does not
                 begin with a "$".
-            ValueError: Raised when the JSONPath has an unsupported operator (an
+            ValueError: Raised when the ReferencePath has an unsupported operator (an
                 operator that Amazon States Language does not support).
         """
         if not self.json_path or str(self.json_path)[0] != "$":
-            raise ValueError('JSONPath must begin with "$"')
+            raise ValueError('ReferencePath must begin with "$"')
 
         unsupported_operators = {"@", "..", ",", ":", "?", "*"}
         for operator in unsupported_operators:
             if operator in str(self.json_path):
-                raise ValueError(f'Unsupported JSONPath operator: "{operator}"')
+                raise ValueError(f'Unsupported ReferencePath operator: "{operator}"')
 
     def apply(self, data: dict) -> Any:
-        """Parse then apply a JSONPath on some data.
+        """Parse then apply a ReferencePath on some data.
 
         Args:
-            data: The data to use the JSONPath expression on.
+            data: The data to use the ReferencePath expression on.
 
         Returns:
             The queried data.

--- a/src/awsstepfuncs/reference_path.py
+++ b/src/awsstepfuncs/reference_path.py
@@ -9,20 +9,20 @@ class ReferencePath:
     See: https://github.com/json-path/JsonPath
     """
 
-    def __init__(self, json_path: str, /):
+    def __init__(self, reference_path: str, /):
         """Initialize a ReferencePath.
 
-        >>> json_path = ReferencePath("$.detail.sum")
-        >>> json_path.apply({"show": True, "detail": {"mean": 10.4, "sum": 2000}})
+        >>> reference_path = ReferencePath("$.detail.sum")
+        >>> reference_path.apply({"show": True, "detail": {"mean": 10.4, "sum": 2000}})
         2000
 
         Args:
-            json_path: The ReferencePath string to use.
+            reference_path: The ReferencePath string to use.
 
         Raises:
             ValueError: Raised when the ReferencePath is malformed.
         """
-        self.json_path = json_path or "$"
+        self.reference_path = reference_path or "$"
         try:
             self._validate()
         except ValueError:
@@ -37,23 +37,23 @@ class ReferencePath:
         Returns:
             The string representation of the ReferencePath.
         """
-        return f"{self.__class__.__name__}({self.json_path!r})"
+        return f"{self.__class__.__name__}({self.reference_path!r})"
 
     def __str__(self) -> str:
         """Return the ReferencePath string.
 
-        >>> json_path = ReferencePath("$.detail.sum")
-        >>> print(json_path)
+        >>> reference_path = ReferencePath("$.detail.sum")
+        >>> print(reference_path)
         $.detail.sum
 
         Returns:
             The human-readable string representation of the ReferencePath.
         """
-        return self.json_path
+        return self.reference_path
 
     def __bool__(self) -> bool:
         """Whether the ReferencePath has something besides $ (default)."""
-        return self.json_path != "$"
+        return self.reference_path != "$"
 
     def _validate(self) -> None:
         """Validate a ReferencePath for Amazon States Language.
@@ -64,12 +64,12 @@ class ReferencePath:
             ValueError: Raised when the ReferencePath has an unsupported operator (an
                 operator that Amazon States Language does not support).
         """
-        if not self.json_path or str(self.json_path)[0] != "$":
+        if not self.reference_path or str(self.reference_path)[0] != "$":
             raise ValueError('ReferencePath must begin with "$"')
 
         unsupported_operators = {"@", "..", ",", ":", "?", "*"}
         for operator in unsupported_operators:
-            if operator in str(self.json_path):
+            if operator in str(self.reference_path):
                 raise ValueError(f'Unsupported ReferencePath operator: "{operator}"')
 
     def apply(self, data: dict) -> Any:
@@ -81,7 +81,7 @@ class ReferencePath:
         Returns:
             The queried data.
         """
-        parsed_json_path = parse_jsonpath(self.json_path)
-        if matches := [match.value for match in parsed_json_path.find(data)]:
+        parsed_reference_path = parse_jsonpath(self.reference_path)
+        if matches := [match.value for match in parsed_reference_path.find(data)]:
             assert len(matches) == 1, "There should only be one match possible"
             return matches[0]

--- a/src/awsstepfuncs/state.py
+++ b/src/awsstepfuncs/state.py
@@ -32,7 +32,7 @@ from awsstepfuncs.abstract_state import (
     AbstractRetryCatchState,
     AbstractState,
 )
-from awsstepfuncs.json_path import ReferencePath
+from awsstepfuncs.reference_path import ReferencePath
 from awsstepfuncs.state_machine import StateMachine
 from awsstepfuncs.types import ResourceToMockFn
 

--- a/src/awsstepfuncs/state.py
+++ b/src/awsstepfuncs/state.py
@@ -32,7 +32,7 @@ from awsstepfuncs.abstract_state import (
     AbstractRetryCatchState,
     AbstractState,
 )
-from awsstepfuncs.json_path import JSONPath
+from awsstepfuncs.json_path import ReferencePath
 from awsstepfuncs.state_machine import StateMachine
 from awsstepfuncs.types import ResourceToMockFn
 
@@ -176,7 +176,7 @@ class Condition:
         Raises:
             ValueError: Raised when there is not exactly one "clause" defined.
         """
-        self.variable = JSONPath(variable)
+        self.variable = ReferencePath(variable)
 
         if (
             sum(
@@ -199,7 +199,9 @@ class Condition:
         self.is_present = is_present
         self.numeric_greater_than_equals = numeric_greater_than_equals
         self.numeric_greater_than_path = (
-            JSONPath(numeric_greater_than_path) if numeric_greater_than_path else None
+            ReferencePath(numeric_greater_than_path)
+            if numeric_greater_than_path
+            else None
         )
         self.numeric_less_than = numeric_less_than
 
@@ -740,8 +742,8 @@ class WaitState(AbstractNextOrEndState):
 
         self.seconds = seconds
         self.timestamp = timestamp
-        self.seconds_path = JSONPath(seconds_path) if seconds_path else None
-        self.timestamp_path = JSONPath(timestamp_path) if timestamp_path else None
+        self.seconds_path = ReferencePath(seconds_path) if seconds_path else None
+        self.timestamp_path = ReferencePath(timestamp_path) if timestamp_path else None
 
     def compile(self) -> Dict[str, Any]:  # noqa: A003
         """Compile the state to Amazon States Language.
@@ -1155,7 +1157,7 @@ class MapState(AbstractRetryCatchState):
             The output of the state by running the iterator state machine for
             all items.
         """
-        items = JSONPath(self.items_path).apply(state_input)
+        items = ReferencePath(self.items_path).apply(state_input)
         print(f"Items after applying items_path of {self.items_path}: {items}")
         if not isinstance(items, list):
             raise ValueError("items_path must yield a list")

--- a/tests/test_json_path.py
+++ b/tests/test_json_path.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from awsstepfuncs.json_path import JSONPath
+from awsstepfuncs.json_path import ReferencePath
 
 
 @pytest.fixture(scope="session")
@@ -21,21 +21,23 @@ def sample_data():
     [("$.foo", 123), ("$.bar", ["a", "b", "c"]), ("$.car.cdr", True)],
 )
 def test_apply_json_path(json_path, match, sample_data):
-    assert JSONPath(json_path).apply(sample_data) == match
+    assert ReferencePath(json_path).apply(sample_data) == match
 
 
 def test_json_path_unsupported_operator():
-    with pytest.raises(ValueError, match='Unsupported JSONPath operator: "*"'):
-        JSONPath("$foo[*].baz")
+    with pytest.raises(ValueError, match='Unsupported ReferencePath operator: "*"'):
+        ReferencePath("$foo[*].baz")
 
 
 def test_json_path_must_begin_with_dollar():
-    with pytest.raises(ValueError, match=re.escape('JSONPath must begin with "$"')):
-        JSONPath("foo[*].baz")
+    with pytest.raises(
+        ValueError, match=re.escape('ReferencePath must begin with "$"')
+    ):
+        ReferencePath("foo[*].baz")
 
 
 def test_apply_json_path_no_match(sample_data):
-    assert JSONPath("$.notfound").apply(sample_data) is None
+    assert ReferencePath("$.notfound").apply(sample_data) is None
 
 
 @pytest.mark.parametrize(
@@ -60,4 +62,4 @@ def test_apply_json_path_no_match(sample_data):
 )
 def test_valid_reference_path(reference_path):
     # Should not raise any ValueError
-    JSONPath(reference_path)
+    ReferencePath(reference_path)

--- a/tests/test_pass_state.py
+++ b/tests/test_pass_state.py
@@ -110,7 +110,7 @@ def test_input_path_output_path(compile_state_machine):
 
 def test_state_has_invalid_input_path():
     invalid_input_path = "$.dataset*"
-    with pytest.raises(ValueError, match='Unsupported JSONPath operator: "*"'):
+    with pytest.raises(ValueError, match='Unsupported ReferencePath operator: "*"'):
         PassState("Pass 1", input_path=invalid_input_path)
 
 

--- a/tests/test_reference_path.py
+++ b/tests/test_reference_path.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from awsstepfuncs.json_path import ReferencePath
+from awsstepfuncs.reference_path import ReferencePath
 
 
 @pytest.fixture(scope="session")
@@ -17,26 +17,26 @@ def sample_data():
 
 
 @pytest.mark.parametrize(
-    ("json_path", "match"),
+    ("reference_path", "match"),
     [("$.foo", 123), ("$.bar", ["a", "b", "c"]), ("$.car.cdr", True)],
 )
-def test_apply_json_path(json_path, match, sample_data):
-    assert ReferencePath(json_path).apply(sample_data) == match
+def test_apply_reference_path(reference_path, match, sample_data):
+    assert ReferencePath(reference_path).apply(sample_data) == match
 
 
-def test_json_path_unsupported_operator():
+def test_reference_path_unsupported_operator():
     with pytest.raises(ValueError, match='Unsupported ReferencePath operator: "*"'):
         ReferencePath("$foo[*].baz")
 
 
-def test_json_path_must_begin_with_dollar():
+def test_reference_path_must_begin_with_dollar():
     with pytest.raises(
         ValueError, match=re.escape('ReferencePath must begin with "$"')
     ):
         ReferencePath("foo[*].baz")
 
 
-def test_apply_json_path_no_match(sample_data):
+def test_apply_reference_path_no_match(sample_data):
     assert ReferencePath("$.notfound").apply(sample_data) is None
 
 

--- a/tests/test_task_state.py
+++ b/tests/test_task_state.py
@@ -248,7 +248,7 @@ def test_result_path_keep_both(compile_state_machine, dummy_resource):
 
 def test_state_has_invalid_result_selector(dummy_resource):
     invalid_result_selector = {"ClusterId.$": "$.dataset*"}
-    with pytest.raises(ValueError, match='Unsupported JSONPath operator: "*"'):
+    with pytest.raises(ValueError, match='Unsupported ReferencePath operator: "*"'):
         TaskState(
             "My Task",
             resource=dummy_resource,


### PR DESCRIPTION
Amazon States Language Reference Path is a subset of JSONPath (eg. can only point to one node unambiguously).