### PR TITLE
Make state input positional when simulating

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ def mock_times_two(data):
     return data
 
 state_output = state_machine.simulate(
-    state_input={"foo": 5, "bar": 1},
+    {"foo": 5, "bar": 1},
     resource_to_mock_fn={
         times_two_resource: mock_times_two,
     },

--- a/src/awsstepfuncs/abstract_state.py
+++ b/src/awsstepfuncs/abstract_state.py
@@ -152,7 +152,7 @@ class AbstractInputPathOutputPathState(AbstractState):
     >>> pass_state = PassState("Pass 1", input_path=input_path, output_path=output_path)
     >>> state_machine = StateMachine(start_state=pass_state)
     >>> _ = state_machine.simulate(
-    ...     state_input={
+    ...     {
     ...         "comment": "Example for InputPath.",
     ...         "dataset1": {"val1": 1, "val2": 2, "val3": 3},
     ...         "dataset2": {"val1": "a", "val2": "b", "val3": "c"},

--- a/src/awsstepfuncs/state.py
+++ b/src/awsstepfuncs/state.py
@@ -126,7 +126,7 @@ class SucceedState(TerminalStateMixin, AbstractInputPathOutputPathState):
 
     >>> succeed_state = SucceedState("Success!")
     >>> state_machine = StateMachine(start_state=succeed_state)
-    >>> _ = state_machine.simulate(state_input={"Hello": "world!"})
+    >>> _ = state_machine.simulate({"Hello": "world!"})
     Starting simulation of state machine
     Running SucceedState('Success!')
     State input: {'Hello': 'world!'}
@@ -192,7 +192,7 @@ class ChoiceState(TerminalStateMixin, AbstractInputPathOutputPathState):
     ...     default=record_event_state,
     ... )
     >>> state_machine = StateMachine(start_state=choice_state)
-    >>> _ = state_machine.simulate(state_input={"type": "Private", "value": 22})
+    >>> _ = state_machine.simulate({"type": "Private", "value": 22})
     Starting simulation of state machine
     Running ChoiceState('DispatchEvent')
     State input: {'type': 'Private', 'value': 22}
@@ -209,7 +209,7 @@ class ChoiceState(TerminalStateMixin, AbstractInputPathOutputPathState):
 
     If no choice evaluates to true, then the default will be chosen.
 
-    >>> _ = state_machine.simulate(state_input={
+    >>> _ = state_machine.simulate({
     ...     "type": "Private",
     ...     "value": 102,
     ...     "auditThreshold": 150,
@@ -257,7 +257,7 @@ class ChoiceState(TerminalStateMixin, AbstractInputPathOutputPathState):
     ...     ],
     ... )
     >>> state_machine = StateMachine(start_state=choice_state)
-    >>> _ = state_machine.simulate(state_input={
+    >>> _ = state_machine.simulate({
     ...     "type": "Private",
     ...     "value": 102,
     ...     "auditThreshold": 150,
@@ -379,7 +379,7 @@ class WaitState(AbstractNextOrEndState):
 
     >>> wait_state = WaitState("Wait!", seconds_path="$.numSeconds")
     >>> state_machine = StateMachine(start_state=wait_state)
-    >>> state_output = state_machine.simulate(state_input={"numSeconds": 1})
+    >>> state_output = state_machine.simulate({"numSeconds": 1})
     Starting simulation of state machine
     Running WaitState('Wait!', seconds_path='$.numSeconds')
     State input: {'numSeconds': 1}
@@ -395,7 +395,7 @@ class WaitState(AbstractNextOrEndState):
 
     >>> wait_state = WaitState("Wait!", seconds_path="$.numSeconds")
     >>> state_machine = StateMachine(start_state=wait_state)
-    >>> state_output = state_machine.simulate(state_input={"numSeconds": "hello"})
+    >>> state_output = state_machine.simulate({"numSeconds": "hello"})
     Starting simulation of state machine
     Running WaitState('Wait!', seconds_path='$.numSeconds')
     State input: {'numSeconds': 'hello'}
@@ -409,7 +409,7 @@ class WaitState(AbstractNextOrEndState):
 
     >>> wait_state = WaitState("Wait!", timestamp_path="$.meta.timeToWait")
     >>> state_machine = StateMachine(start_state=wait_state)
-    >>> state_output = state_machine.simulate(state_input={"meta": {"timeToWait": "2020-01-01T00:00:00"}})
+    >>> state_output = state_machine.simulate({"meta": {"timeToWait": "2020-01-01T00:00:00"}})
     Starting simulation of state machine
     Running WaitState('Wait!', timestamp_path='$.meta.timeToWait')
     State input: {'meta': {'timeToWait': '2020-01-01T00:00:00'}}
@@ -651,7 +651,7 @@ class PassState(AbstractParametersState):
     >>> result = {"Hello": "world!"}
     >>> pass_state = PassState("Passing", result=result, result_path="$.result")
     >>> state_machine = StateMachine(start_state=pass_state)
-    >>> _ = state_machine.simulate(state_input={"sum": 42})
+    >>> _ = state_machine.simulate({"sum": 42})
     Starting simulation of state machine
     Running PassState('Passing')
     State input: {'sum': 42}
@@ -824,7 +824,7 @@ class MapState(AbstractRetryCatchState):
     ...     state_input["quantity"] *= 2
     ...     return state_input
     >>> _ = state_machine.simulate(
-    ...     state_input=state_input,
+    ...     state_input,
     ...     resource_to_mock_fn={resource: mock_fn},
     ... )
     Starting simulation of state machine
@@ -887,7 +887,7 @@ class MapState(AbstractRetryCatchState):
     ... )
     >>> state_machine = StateMachine(start_state=map_state)
     >>> _ = state_machine.simulate(
-    ...     state_input=state_input,
+    ...     state_input,
     ...     resource_to_mock_fn={resource: mock_fn},
     ... )
     Starting simulation of state machine
@@ -964,8 +964,6 @@ class MapState(AbstractRetryCatchState):
         state_output = []
         for item in items:
             state_output.append(
-                self.iterator.simulate(
-                    state_input=item, resource_to_mock_fn=resource_to_mock_fn
-                )
+                self.iterator.simulate(item, resource_to_mock_fn=resource_to_mock_fn)
             )
         return state_output

--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -113,8 +113,9 @@ class StateMachine:
 
     def simulate(  # noqa: CCR001
         self,
-        *,
         state_input: dict = None,
+        /,
+        *,
         resource_to_mock_fn: ResourceToMockFn = None,
         show_visualization: bool = False,
     ) -> Any:

--- a/src/awsstepfuncs/visualization.py
+++ b/src/awsstepfuncs/visualization.py
@@ -84,7 +84,7 @@ class Visualization:
     ... )
     >>> state_machine = StateMachine(start_state=choice_state)
     >>> _ = state_machine.simulate(
-    ...     state_input={"type": "Private", "value": 22}, show_visualization=True
+    ...     {"type": "Private", "value": 22}, show_visualization=True
     ... )
     Starting simulation of state machine
     Running ChoiceState('DispatchEvent')
@@ -137,7 +137,7 @@ class Visualization:
     ... )
     >>> state_machine = StateMachine(start_state=choice_state)
     >>> _ = state_machine.simulate(
-    ...     state_input={"type": "Private", "value": 102, "auditThreshold": 150},
+    ...     {"type": "Private", "value": 102, "auditThreshold": 150},
     ...     show_visualization=True
     ... )
     Starting simulation of state machine

--- a/tests/test_task_state.py
+++ b/tests/test_task_state.py
@@ -47,7 +47,7 @@ def test_task_state(compile_state_machine, dummy_resource):
     with contextlib.closing(StringIO()) as fp:
         with redirect_stdout(fp):
             state_output = state_machine.simulate(
-                state_input={"foo": 5, "bar": 1},
+                {"foo": 5, "bar": 1},
                 resource_to_mock_fn={dummy_resource: mock_fn},
             )
         stdout = [line for line in fp.getvalue().split("\n") if line]
@@ -157,7 +157,7 @@ def test_result_path_only_state_output(compile_state_machine, dummy_resource):
         return output_text
 
     state_output = state_machine.simulate(
-        state_input=state_input,
+        state_input,
         resource_to_mock_fn={dummy_resource: mock_fn},
     )
 
@@ -194,7 +194,7 @@ def test_result_path_only_state_input(compile_state_machine, dummy_resource):
         return "Hello, AWS Step Functions!"
 
     state_output = state_machine.simulate(
-        state_input=state_input,
+        state_input,
         resource_to_mock_fn={dummy_resource: mock_fn},
     )
 
@@ -236,7 +236,7 @@ def test_result_path_keep_both(compile_state_machine, dummy_resource):
         return output_text
 
     state_output = state_machine.simulate(
-        state_input=state_input,
+        state_input,
         resource_to_mock_fn={dummy_resource: mock_fn},
     )
 

--- a/tests/test_wait_state.py
+++ b/tests/test_wait_state.py
@@ -15,7 +15,7 @@ def test_wait_state_later_timestamp():
     # Simulate the state machine
     with contextlib.closing(StringIO()) as fp:
         with redirect_stdout(fp):
-            state_machine.simulate(state_input=state_input)
+            state_machine.simulate(state_input)
         stdout = fp.getvalue()
 
     assert f"Waiting until {timestamp.isoformat()}" in stdout


### PR DESCRIPTION
The API seems cleaner this way, but if there's no state input you (still) don't have to pass an empty dictionary.