### PR TITLE
Make mock functions use same language as Lambda handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ task_state.add_catcher(["States.ALL"], next_state=pass_state)
 
 state_machine = StateMachine(start_state=task_state)
 
-def failure_mock_fn(_):
+def failure_mock_fn(event, context):
     assert False
 
 state_machine.simulate(
@@ -119,9 +119,9 @@ state_machine.to_json("state_machine.json")
 The second use case is to simulate the state machine by defining mock functions for any resource and passing in some input data. The simulation of the state machine allows you to easily debug what's going on and if your state machine works as expected.
 
 ```py
-def mock_times_two(data):
-    data["foo"] *= 2
-    return data
+def mock_times_two(event, context):
+    event["foo"] *= 2
+    return event
 
 state_output = state_machine.simulate(
     {"foo": 5, "bar": 1},

--- a/src/awsstepfuncs/abstract_state.py
+++ b/src/awsstepfuncs/abstract_state.py
@@ -651,7 +651,7 @@ class AbstractRetryCatchState(AbstractResultSelectorState):
         >>> _ = pass_state >> fail_state
         >>> _ = task_state.add_catcher(["States.ALL"], next_state=pass_state)
         >>> state_machine = StateMachine(start_state=task_state)
-        >>> def failure_mock_fn(_):
+        >>> def failure_mock_fn(event, context):
         ...     assert False
         >>> _ = state_machine.simulate(resource_to_mock_fn={resource: failure_mock_fn})
         Starting simulation of state machine

--- a/src/awsstepfuncs/state.py
+++ b/src/awsstepfuncs/state.py
@@ -773,19 +773,27 @@ class TaskState(AbstractRetryCatchState):
         compiled["Resource"] = self.resource
         return compiled
 
-    def _execute(self, state_input: Any, resource_to_mock_fn: ResourceToMockFn) -> Any:
+    def _execute(
+        self,
+        state_input: Any,
+        resource_to_mock_fn: ResourceToMockFn,
+        parameters: Dict[str, Any] = None,
+    ) -> Any:
         """Execute the Task State.
 
         Args:
             state_input: The input state data.
             resource_to_mock_fn: A mapping of resource URIs to mock functions to
                 use if the state performs a task.
+            parameters: Parameters are passed as the context to the mock
+                function.
 
         Returns:
             The output of the state from executing the mock function given the
             state's input.
         """
-        return resource_to_mock_fn[self.resource](state_input)
+        # TODO: Implement parameters
+        return resource_to_mock_fn[self.resource](state_input, parameters or {})
 
 
 class ParallelState(AbstractRetryCatchState):
@@ -821,9 +829,9 @@ class MapState(AbstractRetryCatchState):
     ...        ],
     ...    },
     ... }
-    >>> def mock_fn(state_input):
-    ...     state_input["quantity"] *= 2
-    ...     return state_input
+    >>> def mock_fn(event, context):
+    ...     event["quantity"] *= 2
+    ...     return event
     >>> _ = state_machine.simulate(
     ...     state_input,
     ...     resource_to_mock_fn={resource: mock_fn},

--- a/src/awsstepfuncs/types.py
+++ b/src/awsstepfuncs/types.py
@@ -1,3 +1,3 @@
 from typing import Any, Callable, Dict
 
-ResourceToMockFn = Dict[str, Callable[[Any], Any]]
+ResourceToMockFn = Dict[str, Callable[[Dict[str, Any], Dict[str, Any]], Any]]

--- a/src/awsstepfuncs/visualization.py
+++ b/src/awsstepfuncs/visualization.py
@@ -25,7 +25,7 @@ class Visualization:
     >>> _ = pass_state >> fail_state
     >>> _ = task_state.add_catcher(["States.ALL"], next_state=pass_state)
     >>> state_machine = StateMachine(start_state=task_state)
-    >>> def failure_mock_fn(_):
+    >>> def failure_mock_fn(event, context):
     ...     assert False
     >>> _ = state_machine.simulate(
     ...     resource_to_mock_fn={resource: failure_mock_fn}, show_visualization=True

--- a/tests/test_task_state.py
+++ b/tests/test_task_state.py
@@ -40,9 +40,9 @@ def test_task_state(compile_state_machine, dummy_resource):
 
     # Simulate the state machine
 
-    def mock_fn(data):
-        data["foo"] *= 2
-        return data
+    def mock_fn(event, context):
+        event["foo"] *= 2
+        return event
 
     with contextlib.closing(StringIO()) as fp:
         with redirect_stdout(fp):
@@ -98,7 +98,7 @@ def test_result_selector(compile_state_machine, dummy_resource):
 
     # Simulate the state machine
 
-    def mock_fn(_):
+    def mock_fn(event, context):
         return {
             "resourceType": "elasticmapreduce",
             "resource": "createCluster.sync",
@@ -153,7 +153,7 @@ def test_result_path_only_state_output(compile_state_machine, dummy_resource):
 
     output_text = "Hello, AWS Step Functions!"
 
-    def mock_fn(_):
+    def mock_fn(event, context):
         return output_text
 
     state_output = state_machine.simulate(
@@ -190,7 +190,7 @@ def test_result_path_only_state_input(compile_state_machine, dummy_resource):
         "who": "AWS Step Functions",
     }
 
-    def mock_fn(_):
+    def mock_fn(event, context):
         return "Hello, AWS Step Functions!"
 
     state_output = state_machine.simulate(
@@ -232,7 +232,7 @@ def test_result_path_keep_both(compile_state_machine, dummy_resource):
 
     output_text = "Hello, AWS Step Functions!"
 
-    def mock_fn(_):
+    def mock_fn(event, context):
         return output_text
 
     state_output = state_machine.simulate(


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html

I'm not 100% sure the relationship between Parameters and the Lambda handler context, but this looks more correct than it was before.

Right now the implementation definitely doesn't seem correct of passing Parameters directly as the context, but will leave it for now.