### PR TITLE
Add base exception and derived value error for lib

### DIFF
--- a/src/awsstepfuncs/__init__.py
+++ b/src/awsstepfuncs/__init__.py
@@ -8,6 +8,7 @@ from awsstepfuncs.choice import (  # noqa: F401
     NotChoice,
     VariableChoice,
 )
+from awsstepfuncs.errors import AWSStepFuncsValueError  # noqa: F401
 from awsstepfuncs.state import (  # noqa: F401
     ChoiceState,
     FailState,

--- a/src/awsstepfuncs/__init__.py
+++ b/src/awsstepfuncs/__init__.py
@@ -8,7 +8,7 @@ from awsstepfuncs.choice import (  # noqa: F401
     NotChoice,
     VariableChoice,
 )
-from awsstepfuncs.errors import AWSStepFuncsValueError  # noqa: F401
+from awsstepfuncs.errors import AWSStepFuncsError, AWSStepFuncsValueError  # noqa: F401
 from awsstepfuncs.state import (  # noqa: F401
     ChoiceState,
     FailState,

--- a/src/awsstepfuncs/choice.py
+++ b/src/awsstepfuncs/choice.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Any, List, Union
 
 from awsstepfuncs.abstract_state import AbstractState
+from awsstepfuncs.errors import AWSStepFuncsValueError
 from awsstepfuncs.reference_path import ReferencePath
 
 
@@ -105,7 +106,7 @@ class ChoiceRule:
     >>> ChoiceRule("$.career", string_equals="Pirate", is_present=True)
     Traceback (most recent call last):
         ...
-    ValueError: Exactly one data-test expression must be defined
+    awsstepfuncs.errors.AWSStepFuncsValueError: Exactly one data-test expression must be defined
 
     Be careful that if you specify a Reference Path that it evaluates to a value
     with the expected type.
@@ -114,7 +115,7 @@ class ChoiceRule:
     >>> salary_rule.evaluate({"salary": "100_000", "expectedSalary": 100_000})
     Traceback (most recent call last):
         ...
-    ValueError: string_equals_path must evaluate to a string value
+    awsstepfuncs.errors.AWSStepFuncsValueError: string_equals_path must evaluate to a string value
 
     There are many different data-test expressions to choose from:
 
@@ -215,13 +216,15 @@ class ChoiceRule:
             data_test_expression: The data-test expression to use.
 
         Raises:
-            ValueError: Raised when there is not exactly one data-test
+            AWSStepFuncsValueError: Raised when there is not exactly one data-test
                 expression defined.
         """
         self.variable = ReferencePath(variable)
 
         if len(data_test_expression) != 1:
-            raise ValueError("Exactly one data-test expression must be defined")
+            raise AWSStepFuncsValueError(
+                "Exactly one data-test expression must be defined"
+            )
 
         self.data_test_expression = DataTestExpression(
             *list(data_test_expression.items())[0]
@@ -266,7 +269,9 @@ class ChoiceRule:
     def _string_equals_path(self, data: Any, variable_value: str) -> bool:
         string_equals = self.data_test_expression.expression.apply(data)  # type: ignore
         if not (isinstance(string_equals, str)):
-            raise ValueError("string_equals_path must evaluate to a string value")
+            raise AWSStepFuncsValueError(
+                "string_equals_path must evaluate to a string value"
+            )
         return variable_value == string_equals
 
     def _string_greater_than(self, variable_value: str) -> bool:
@@ -275,7 +280,9 @@ class ChoiceRule:
     def _string_greater_than_path(self, data: Any, variable_value: str) -> bool:
         string_greater_than = self.data_test_expression.expression.apply(data)  # type: ignore
         if not (isinstance(string_greater_than, str)):  # pragma: no cover
-            raise ValueError("string_greater_than_path must evaluate to a string value")
+            raise AWSStepFuncsValueError(
+                "string_greater_than_path must evaluate to a string value"
+            )
         return variable_value > string_greater_than
 
     def _string_less_than(self, variable_value: str) -> bool:
@@ -284,7 +291,9 @@ class ChoiceRule:
     def _string_less_than_path(self, data: Any, variable_value: str) -> bool:
         string_less_than = self.data_test_expression.expression.apply(data)  # type: ignore
         if not (isinstance(string_less_than, str)):  # pragma: no cover
-            raise ValueError("string_less_than_path must evaluate to a string value")
+            raise AWSStepFuncsValueError(
+                "string_less_than_path must evaluate to a string value"
+            )
         return variable_value < string_less_than
 
     def _string_greater_than_equals(self, variable_value: str) -> bool:
@@ -293,7 +302,7 @@ class ChoiceRule:
     def _string_greater_than_equals_path(self, data: Any, variable_value: str) -> bool:
         string_greater_than_equals = self.data_test_expression.expression.apply(data)  # type: ignore
         if not (isinstance(string_greater_than_equals, str)):  # pragma: no cover
-            raise ValueError(
+            raise AWSStepFuncsValueError(
                 "string_greater_than_equals_path must evaluate to a string value"
             )
         return variable_value >= string_greater_than_equals
@@ -304,7 +313,7 @@ class ChoiceRule:
     def _string_less_than_equals_path(self, data: Any, variable_value: str) -> bool:
         string_less_than_equals = self.data_test_expression.expression.apply(data)  # type: ignore
         if not (isinstance(string_less_than_equals, str)):  # pragma: no cover
-            raise ValueError(
+            raise AWSStepFuncsValueError(
                 "string_less_than_equals_path must evaluate to a string value"
             )
         return variable_value <= string_less_than_equals
@@ -320,7 +329,7 @@ class ChoiceRule:
             isinstance(numeric_greater_than, int)
             or isinstance(numeric_greater_than, float)
         ):
-            raise ValueError(
+            raise AWSStepFuncsValueError(
                 "numeric_greater_than_path must evaluate to a numeric value"
             )
         return variable_value > numeric_greater_than
@@ -501,7 +510,7 @@ class VariableChoice(AbstractChoice):
     >>> variable_choice.evaluate({"rating": 53, "auditThreshold": "50"})
     Traceback (most recent call last):
         ...
-    ValueError: numeric_greater_than_path must evaluate to a numeric value
+    awsstepfuncs.errors.AWSStepFuncsValueError: numeric_greater_than_path must evaluate to a numeric value
     """
 
     def __init__(

--- a/src/awsstepfuncs/errors.py
+++ b/src/awsstepfuncs/errors.py
@@ -1,0 +1,28 @@
+class AWSStepFuncsError(Exception):
+    """Base error for this package.
+
+    This is useful for client code to know whether the error is expected or
+    whether there is a bug in the library code.
+
+    >>> from awsstepfuncs import *
+
+    >>> try:
+    ...     wait_state = WaitState("Wait!", seconds=-1)
+    ... except AWSStepFuncsError:
+    ...     print("Error in the client")
+    ... except Exception:
+    ...     print("Error in awsstepfuncs")
+    Error in the client
+    """
+
+
+class AWSStepFuncsValueError(AWSStepFuncsError):
+    """A bad value was specified.
+
+    >>> from awsstepfuncs import *
+
+    >>> wait_state = WaitState("Wait!", seconds=-1)
+    Traceback (most recent call last):
+        ...
+    awsstepfuncs.errors.AWSStepFuncsValueError: seconds must be greater than zero
+    """

--- a/src/awsstepfuncs/reference_path.py
+++ b/src/awsstepfuncs/reference_path.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from jsonpath_rw import parse as parse_jsonpath
 
+from awsstepfuncs.errors import AWSStepFuncsValueError
+
 
 class ReferencePath:
     """Reference Path validation and application.
@@ -24,12 +26,12 @@ class ReferencePath:
             reference_path: The Reference Path string to use (a JSONPath).
 
         Raises:
-            ValueError: Raised when the Reference Path is malformed.
+            AWSStepFuncsValueError: Raised when the Reference Path is malformed.
         """
         self.reference_path = reference_path or "$"
         try:
             self._validate()
-        except ValueError:
+        except AWSStepFuncsValueError:
             raise
 
     def __repr__(self) -> str:
@@ -63,18 +65,20 @@ class ReferencePath:
         """Validate a Reference Path for Amazon States Language.
 
         Raises:
-            ValueError: Raised when Reference Path is an empty string or does not
+            AWSStepFuncsValueError: Raised when Reference Path is an empty string or does not
                 begin with a "$".
-            ValueError: Raised when the Reference Path has an unsupported operator (an
+            AWSStepFuncsValueError: Raised when the Reference Path has an unsupported operator (an
                 operator that Amazon States Language does not support).
         """
         if not self.reference_path or str(self.reference_path)[0] != "$":
-            raise ValueError('Reference Path must begin with "$"')
+            raise AWSStepFuncsValueError('Reference Path must begin with "$"')
 
         unsupported_operators = {"@", "..", ",", ":", "?", "*"}
         for operator in unsupported_operators:
             if operator in str(self.reference_path):
-                raise ValueError(f'Unsupported Reference Path operator: "{operator}"')
+                raise AWSStepFuncsValueError(
+                    f'Unsupported Reference Path operator: "{operator}"'
+                )
 
     def apply(self, data: dict) -> Any:
         """Parse then apply a Reference Path on some data.

--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set, Tuple, Union
 
 from awsstepfuncs.abstract_state import AbstractRetryCatchState, AbstractState
+from awsstepfuncs.errors import AWSStepFuncsValueError
 from awsstepfuncs.types import ResourceToMockFn
 from awsstepfuncs.visualization import Visualization
 
@@ -33,12 +34,12 @@ class StateMachine:
                 "1.0".
 
         Raises:
-            ValueError: Raised when there are duplicate state names.
+            AWSStepFuncsValueError: Raised when there are duplicate state names.
         """
         self.start_state = start_state
 
         if not self._has_unique_names():
-            raise ValueError(
+            raise AWSStepFuncsValueError(
                 "Duplicate names detected in state machine. Names must be unique"
             )
 

--- a/src/awsstepfuncs/visualization.py
+++ b/src/awsstepfuncs/visualization.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 import gvanim
 
 from awsstepfuncs.abstract_state import AbstractState
+from awsstepfuncs.errors import AWSStepFuncsValueError
 
 
 class Visualization:
@@ -179,7 +180,7 @@ class Visualization:
         >>> Visualization(start_state=state, output_path="state_machine.png")
         Traceback (most recent call last):
                 ...
-        ValueError: Visualization output path must end with ".gif"
+        awsstepfuncs.errors.AWSStepFuncsValueError: Visualization output path must end with ".gif"
 
         Args:
             start_state: The starting state of the state machine, used to
@@ -187,13 +188,15 @@ class Visualization:
             output_path: What path to save the visualization GIF to.
 
         Raises:
-            ValueError: Raised when the output path doesn't end with `.gif`.
+            AWSStepFuncsValueError: Raised when the output path doesn't end with `.gif`.
         """
         self.animation = gvanim.Animation()
         self._build_state_graph(start_state)
 
         if not str(output_path).endswith(".gif"):
-            raise ValueError('Visualization output path must end with ".gif"')
+            raise AWSStepFuncsValueError(
+                'Visualization output path must end with ".gif"'
+            )
 
         self.output_path = Path(output_path)
 

--- a/tests/test_reference_path.py
+++ b/tests/test_reference_path.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 
+from awsstepfuncs import AWSStepFuncsValueError
 from awsstepfuncs.reference_path import ReferencePath
 
 
@@ -25,13 +26,15 @@ def test_apply_reference_path(reference_path, match, sample_data):
 
 
 def test_reference_path_unsupported_operator():
-    with pytest.raises(ValueError, match='Unsupported Reference Path operator: "*"'):
+    with pytest.raises(
+        AWSStepFuncsValueError, match='Unsupported Reference Path operator: "*"'
+    ):
         ReferencePath("$foo[*].baz")
 
 
 def test_reference_path_must_begin_with_dollar():
     with pytest.raises(
-        ValueError, match=re.escape('Reference Path must begin with "$"')
+        AWSStepFuncsValueError, match=re.escape('Reference Path must begin with "$"')
     ):
         ReferencePath("foo[*].baz")
 

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,6 +1,12 @@
 import pytest
 
-from awsstepfuncs import FailState, PassState, StateMachine, TaskState
+from awsstepfuncs import (
+    AWSStepFuncsValueError,
+    FailState,
+    PassState,
+    StateMachine,
+    TaskState,
+)
 
 
 def test_one_state(compile_state_machine):
@@ -29,7 +35,7 @@ def test_duplicate_names():
     pass_state2 = PassState(duplicate_name)
     pass_state1 >> pass_state2
     with pytest.raises(
-        ValueError,
+        AWSStepFuncsValueError,
         match="Duplicate names detected in state machine. Names must be unique",
     ):
         StateMachine(start_state=pass_state1)
@@ -41,7 +47,7 @@ def test_duplicate_names_catcher():
     transition_state = FailState(duplicate_name, error="MyError", cause="Negligence")
     task_state.add_catcher(["Something"], next_state=transition_state)
     with pytest.raises(
-        ValueError,
+        AWSStepFuncsValueError,
         match="Duplicate names detected in state machine. Names must be unique",
     ):
         StateMachine(start_state=task_state)

--- a/tests/test_task_state.py
+++ b/tests/test_task_state.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 import pytest
 
-from awsstepfuncs import PassState, StateMachine, TaskState
+from awsstepfuncs import AWSStepFuncsValueError, PassState, StateMachine, TaskState
 
 
 @pytest.fixture(scope="session")
@@ -248,7 +248,9 @@ def test_result_path_keep_both(compile_state_machine, dummy_resource):
 
 def test_state_has_invalid_result_selector(dummy_resource):
     invalid_result_selector = {"ClusterId.$": "$.dataset*"}
-    with pytest.raises(ValueError, match='Unsupported Reference Path operator: "*"'):
+    with pytest.raises(
+        AWSStepFuncsValueError, match='Unsupported Reference Path operator: "*"'
+    ):
         TaskState(
             "My Task",
             resource=dummy_resource,


### PR DESCRIPTION
This is useful for client code to know whether the error is expected or whether there is a bug in the library code. Technique taken from Effective Python.

```py
>>> from awsstepfuncs import *
>>> try:
...     wait_state = WaitState("Wait!", seconds=-1)
... except AWSStepFuncsError:
...     print("Error in the client")
... except Exception:
...     print("Error in awsstepfuncs")
```
```
Error in the client
```