### PR TITLE
Add simulation support for Fail State

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ As you can see from the standard output, each state is executed and data flows b
 
 | State        | Compile Coverage                                                                                            | Simulation Coverage                                                                                         |
 | ------------ | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Fail**     | :heavy_check_mark:                                                                                          | :heavy_multiplication_x: Missing error handling                                                             |
+| **Fail**     | :heavy_check_mark:                                                                                          | :heavy_check_mark:                                                                                          |
 | **Succeed**  | :heavy_check_mark:                                                                                          | :heavy_check_mark:                                                                                          |
 | **Choice**   | :heavy_multiplication_x:                                                                                    | :heavy_multiplication_x:                                                                                    |
 | **Wait**     | :heavy_check_mark:                                                                                          | :heavy_check_mark:                                                                                          |

--- a/src/awsstepfuncs/abstract_state.py
+++ b/src/awsstepfuncs/abstract_state.py
@@ -5,7 +5,7 @@ Based on this table: https://states-language.net/spec.html#state-type-table
 from __future__ import annotations
 
 import re
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Type, Union
 
 from awsstepfuncs.errors import AWSStepFuncsValueError, StateSimulationError
@@ -65,6 +65,7 @@ class AbstractState(ABC):
             compiled["Comment"] = comment
         return compiled
 
+    @abstractmethod
     def _execute(self, state_input: Any, resource_to_mock_fn: ResourceToMockFn) -> Any:
         """Execute the state.
 
@@ -73,10 +74,11 @@ class AbstractState(ABC):
             resource_to_mock_fn: A mapping of resource URIs to mock functions to
                 use if the state performs a task.
 
-        Returns:
-            An empty output state.
+        Raises:
+            NotImplementedError: Raised when child classes do not implement this
+                method.
         """
-        return {}
+        raise NotImplementedError
 
     def simulate(self, state_input: Any, resource_to_mock_fn: ResourceToMockFn) -> Any:
         """Simulate the state including input and output processing.
@@ -724,6 +726,7 @@ class AbstractRetryCatchState(AbstractResultSelectorState):
         State output: {}
         Executing FailState('Failure', error='IFailed', cause='I failed!')
         State input: {}
+        Error encountered in state, checking for catchers
         State output: {}
         Terminating simulation of state machine
 

--- a/src/awsstepfuncs/errors.py
+++ b/src/awsstepfuncs/errors.py
@@ -105,3 +105,28 @@ class NoChoiceMatchedError(StateSimulationError):
     """Raised when a Choice State failed to pick a next state."""
 
     error_string = "States.NoChoiceMatched"
+
+
+class FailStateError(StateSimulationError):
+    """Raised when running a Fail State."""
+
+    def __init__(self, *, error: str, cause: str):
+        """Initialize a FailStateError.
+
+        Args:
+            error: An error string representing the error.
+            cause: A human-readable description of the error.
+        """
+        self.error_string = error
+        self.cause = cause
+
+    def __repr__(self) -> str:
+        """Return a representation of the FailStateError.
+
+        >>> FailStateError(error="IFailed", cause="I failed!")
+        FailStateError(error='IFailed', cause='I failed!')
+
+        Returns:
+            String representation of the FailStateError.
+        """
+        return f"{self.__class__.__name__}(error={self.error_string!r}, cause={self.cause!r})"

--- a/src/awsstepfuncs/state.py
+++ b/src/awsstepfuncs/state.py
@@ -35,6 +35,7 @@ from awsstepfuncs.abstract_state import (
 from awsstepfuncs.choice import AbstractChoice
 from awsstepfuncs.errors import (
     AWSStepFuncsValueError,
+    FailStateError,
     NoChoiceMatchedError,
     StateSimulationError,
     TaskFailedError,
@@ -79,10 +80,11 @@ class FailState(TerminalStateMixin, AbstractState):
 
     >>> fail_state = FailState("Failure", error="IFailed", cause="I failed!")
     >>> state_machine = StateMachine(start_state=fail_state)
-    >>> state_output = state_machine.simulate()
+    >>> _ = state_machine.simulate()
     Starting simulation of state machine
     Executing FailState('Failure', error='IFailed', cause='I failed!')
     State input: {}
+    Error encountered in state, checking for catchers
     State output: {}
     Terminating simulation of state machine
     """
@@ -117,6 +119,19 @@ class FailState(TerminalStateMixin, AbstractState):
         compiled["Error"] = self.error
         compiled["Cause"] = self.cause
         return compiled
+
+    def _execute(self, state_input: Any, resource_to_mock_fn: ResourceToMockFn) -> Any:
+        """Execute the Fail State.
+
+        Args:
+            state_input: The input state data.
+            resource_to_mock_fn: A mapping of resource URIs to mock functions to
+                use if the state performs a task.
+
+        Raises:
+            FailStateError: Always raised with the error and cause.
+        """
+        raise FailStateError(error=self.error, cause=self.cause)
 
     def __str__(self) -> str:
         """Create a human-readable string representation of a state.

--- a/src/awsstepfuncs/visualization.py
+++ b/src/awsstepfuncs/visualization.py
@@ -46,6 +46,7 @@ class Visualization:
     State output: {}
     Executing FailState('Failure', error='IFailed', cause='I failed!')
     State input: {}
+    Error encountered in state, checking for catchers
     State output: {}
     Terminating simulation of state machine
 


### PR DESCRIPTION
Amazon States Language spec seems to contradict itself:
> A Fail State MUST have a string field named "Error", **used to provide an error name that can be used for error handling (Retry/Catch)**, operational, or diagnostic purposes. A Fail State MUST have a string field named "Cause", used to provide a human-readable message.

Yet, Fail States are shown in the table to not support Retry/Catch:

![image](https://user-images.githubusercontent.com/13723264/99457572-d07c4800-28f0-11eb-97da-452feaef56ff.png)

So, in the implementation it would work to add a Catcher to a Fail State generally except that the method is not defined based on the ABC inheritance that I created based on the table. tldr; it won't work to try to add a Catcher/Retrier to the Fail State in this implementation.

Overall, adding this feature is elegant in the framework I've already set up :blush: 

Closes #120